### PR TITLE
Remove duplicated items when generating string replacement

### DIFF
--- a/src/Tenpureto/Templater.hs
+++ b/src/Tenpureto/Templater.hs
@@ -4,6 +4,7 @@ import           Polysemy
 import           Polysemy.Resource
 
 import           Data.ByteString                ( ByteString )
+import           Data.List
 import           Data.Text                      ( Text )
 import qualified Data.Text                     as T
 import           Data.Set                       ( Set )
@@ -42,7 +43,7 @@ data TemplaterException = TemplaterException
 
 expandReplacement :: (Text, Text) -> [(Text, Text)]
 expandReplacement (a, b) =
-    [ (templateValueText av, templateValueText bv)
+    removeDuplicated [ (templateValueText av, templateValueText bv)
     | av <- variations a
     , bv <- variations b
     , sameStyle av bv
@@ -51,6 +52,7 @@ expandReplacement (a, b) =
     variations text = Set.toList . Set.fromList $ concatMap
         styleVariations
         (textToTemplateValues text)
+    removeDuplicated = nubBy (\(t1, _) (t2, _) -> t1 == t2)
 
 expandReplacements
     :: InsOrdHashMap Text Text -> InsOrdHashMap Text Text -> [(Text, Text)]

--- a/test/Tenpureto/TemplaterTest.hs
+++ b/test/Tenpureto/TemplaterTest.hs
@@ -34,6 +34,41 @@ test_translateFile =
             @?= Right [relfile|a/xxx/yyy/e/f.txt|]
         ]
 
+test_translateFile_toVariablesHasSpace :: [TestTree]
+test_translateFile_toVariablesHasSpace =
+    let Right settings = runTest $ compileSettings TemplaterSettings
+            { templaterFromVariables = InsOrdHashMap.singleton "A" "bbb-ccc-ddd"
+            , templaterToVariables   = InsOrdHashMap.singleton "A" "xxx yyy"
+            , templaterExcludes      = Set.empty
+            }
+        mv = runTest . translateFile settings
+    in  [ testCase "should replace in file name"
+            $   mv [relfile|a-bbb-ccc-ddd-e.txt|]
+            @?= Right [relfile|a-xxx-yyy-e.txt|]
+        , testCase "should replace in path"
+            $   mv [relfile|a/bbb/ccc/ddd/e/f.txt|]
+            @?= Right [relfile|a/xxx/yyy/e/f.txt|]
+        ]
+
+test_translateFile_toVariablesHasUpperCaseCharaters :: [TestTree]
+test_translateFile_toVariablesHasUpperCaseCharaters =
+    let Right settings = runTest $ compileSettings TemplaterSettings
+            { templaterFromVariables = InsOrdHashMap.singleton "A" "bbb-ccc-ddd"
+            , templaterToVariables   = InsOrdHashMap.singleton "A" "Xxx Yyy"
+            , templaterExcludes      = Set.empty
+            }
+        mv = runTest . translateFile settings
+    in  [ testCase "should replace in file name"
+            $   mv [relfile|a-bbb-ccc-ddd-e.txt|]
+            @?= Right [relfile|a-xxx-yyy-e.txt|]
+        , testCase "should replace in path"
+            $   mv [relfile|a/bbb/ccc/ddd/e/f.txt|]
+            @?= Right [relfile|a/xxx/yyy/e/f.txt|]
+        , testCase "should replace in path"
+            $   mv [relfile|a/bbb-ccc-ddd/e/f.txt|]
+            @?= Right [relfile|a/xxx-yyy/e/f.txt|]
+        ]
+
 test_excludes :: [TestTree]
 test_excludes =
     let


### PR DESCRIPTION
Fix #32 