### PR TITLE
Do not use regexps for replacement

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -14,7 +14,8 @@ dependencies:
 - either
 - text
 - text-icu
-- text-regex-replace
+- replace-attoparsec
+- attoparsec
 - path
 - path-io
 - directory

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@ resolver: lts-14.3
 packages:
 - .
 extra-deps:
-- text-regex-replace-0.1.1.3@sha256:e7f612df671c93ced54a3d26528db37852069884e5cb67d5afbb49d3defb5eb9
+- replace-attoparsec-1.0.3.0@sha256:f5a6ed1ab83a2291c3190fc152c76967a1ccafbc488041f51519425716784ea6,2465
 - hedgehog-classes-0.2.2@sha256:1a5b6459ab9af30bd277ac0ecd2986b36584dfa07ceca8b89bf59cecd7883236,5240
 - semirings-0.3.1.2@sha256:ecb57a0ba210409f1376646b3cfd1f48a756ad8ab8467fce98d50e2e15e1c528,3759 # for hedgehog-classes
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: text-regex-replace-0.1.1.3@sha256:e7f612df671c93ced54a3d26528db37852069884e5cb67d5afbb49d3defb5eb9,1627
+    hackage: replace-attoparsec-1.0.3.0@sha256:f5a6ed1ab83a2291c3190fc152c76967a1ccafbc488041f51519425716784ea6,2465
     pantry-tree:
-      size: 360
-      sha256: 0edba698df19381c1fadb494dfd5278b35b6670bf29cab1a228f2fde9bb9ba89
+      size: 592
+      sha256: e316b4238ef761b56f456fab0d97f19d7fed87dce0072608175636be6b916d66
   original:
-    hackage: text-regex-replace-0.1.1.3@sha256:e7f612df671c93ced54a3d26528db37852069884e5cb67d5afbb49d3defb5eb9
+    hackage: replace-attoparsec-1.0.3.0@sha256:f5a6ed1ab83a2291c3190fc152c76967a1ccafbc488041f51519425716784ea6,2465
 - completed:
     hackage: hedgehog-classes-0.2.2@sha256:1a5b6459ab9af30bd277ac0ecd2986b36584dfa07ceca8b89bf59cecd7883236,5240
     pantry-tree:


### PR DESCRIPTION
`replace-attoparsec` looks more supported than `text-regex-replace` and we don't need regular expressions to do string replacement anyway, so it should also be faster now.