### PR TITLE
Get rid of terminal-size dependency

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -27,7 +27,6 @@ dependencies:
 - prettyprinter
 - prettyprinter-ansi-terminal
 - ansi-terminal
-- terminal-size
 - typed-process
 - optparse-applicative
 - yaml

--- a/src/Tenpureto/Effects/Terminal/Internal.hs
+++ b/src/Tenpureto/Effects/Terminal/Internal.hs
@@ -9,6 +9,7 @@ import           Data.Text.Prettyprint.Doc.Render.Terminal
 import           Data.Functor
 import           Data.Traversable
 import           Control.Monad
+import           Control.Exception
 
 import           System.IO                      ( stdout
                                                 , hFlush
@@ -16,8 +17,8 @@ import           System.IO                      ( stdout
 import           System.Console.ANSI            ( cursorUp
                                                 , setCursorColumn
                                                 , clearFromCursorToScreenEnd
+                                                , getTerminalSize
                                                 )
-import qualified System.Console.Terminal.Size  as TS
 
 newtype TemporaryHeight = TemporaryHeight Int
 
@@ -25,7 +26,10 @@ layoutOptions :: Maybe Int -> LayoutOptions
 layoutOptions w = LayoutOptions $ maybe Unbounded (flip AvailablePerLine 1.0) w
 
 getTerminalWidth :: IO (Maybe Int)
-getTerminalWidth = fmap TS.width <$> TS.size
+getTerminalWidth = fmap snd <$> catch getTerminalSize ignore
+  where
+    ignore :: SomeException -> IO (Maybe a)
+    ignore _ = return Nothing
 
 sayLnTerminal :: Doc AnsiStyle -> IO ()
 sayLnTerminal msg = do


### PR DESCRIPTION
`ansi-terminal` has all we need