### PR TITLE
Revert "Get rid of terminal-size dependency"

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -27,6 +27,7 @@ dependencies:
 - prettyprinter
 - prettyprinter-ansi-terminal
 - ansi-terminal
+- terminal-size
 - typed-process
 - optparse-applicative
 - yaml

--- a/src/Tenpureto/Effects/Terminal/Internal.hs
+++ b/src/Tenpureto/Effects/Terminal/Internal.hs
@@ -9,7 +9,6 @@ import           Data.Text.Prettyprint.Doc.Render.Terminal
 import           Data.Functor
 import           Data.Traversable
 import           Control.Monad
-import           Control.Exception
 
 import           System.IO                      ( stdout
                                                 , hFlush
@@ -17,8 +16,8 @@ import           System.IO                      ( stdout
 import           System.Console.ANSI            ( cursorUp
                                                 , setCursorColumn
                                                 , clearFromCursorToScreenEnd
-                                                , getTerminalSize
                                                 )
+import qualified System.Console.Terminal.Size  as TS
 
 newtype TemporaryHeight = TemporaryHeight Int
 
@@ -26,10 +25,7 @@ layoutOptions :: Maybe Int -> LayoutOptions
 layoutOptions w = LayoutOptions $ maybe Unbounded (flip AvailablePerLine 1.0) w
 
 getTerminalWidth :: IO (Maybe Int)
-getTerminalWidth = fmap snd <$> catch getTerminalSize ignore
-  where
-    ignore :: SomeException -> IO (Maybe a)
-    ignore _ = return Nothing
+getTerminalWidth = fmap TS.width <$> TS.size
 
 sayLnTerminal :: Doc AnsiStyle -> IO ()
 sayLnTerminal msg = do


### PR DESCRIPTION
This reverts commit 4779cf8e0b8bfff2d66606e708d6860bbfb6eaa8.

The change was causing issues when running from the first line of a terminal.