### PR TITLE
Treat null YAML values as empty strings

### DIFF
--- a/test/Tenpureto/TemplateLoaderTest.hs
+++ b/test/Tenpureto/TemplateLoaderTest.hs
@@ -177,6 +177,13 @@ test_parseTemplateYaml =
                 , yamlExcludes  = mempty
                 , yamlConflicts = mempty
                 }
+    , testCase "parse nulls"
+        $   parseTemplateYaml "variables: { \"Key\": }"
+        @?= Right TemplateYaml { yamlVariables = Map.singleton "Key" ""
+                               , yamlFeatures  = mempty
+                               , yamlExcludes  = mempty
+                               , yamlConflicts = mempty
+                               }
     ]
 
 test_buildGraph :: [TestTree]


### PR DESCRIPTION
Let `tenpureto` parse the following `.template.yaml`:
```yaml
variables:
  Foo: # looks like an empty string, but is in fact "null"
```