### PR TITLE
Better message when template commit is not found

### DIFF
--- a/src/Tenpureto/Effects/UI/Internal.hs
+++ b/src/Tenpureto/Effects/UI/Internal.hs
@@ -24,16 +24,12 @@ import           Tenpureto.TemplateLoader
 import           Tenpureto.MergeOptimizer
 import           Tenpureto.Effects.Terminal
 import           Tenpureto.Effects.FileSystem
-import           Tenpureto.Effects.Git
 
 inputTemplate :: Member TerminalInput r => Sem r Text
 inputTemplate = ask "Template URL" Nothing
 
 inputTarget :: Members '[TerminalInput, FileSystem] r => Sem r (Path Abs Dir)
 inputTarget = ask "Target directory" Nothing <&> T.unpack >>= resolveDir
-
-inputPreviousCommit :: Member TerminalInput r => Sem r ParentCommit
-inputPreviousCommit = ask "Previous template commit" Nothing <&> (ExistingParentCommit . Committish)
 
 templateBranchesByNames
     :: TemplateInformation -> Set Text -> [TemplateBranchInformation]


### PR DESCRIPTION
If the previous template commit cannot be found automatically, it's unlikely that it can be specified manually, so it makes more sense to just fail with a proper error message.