### PR TITLE
Use HsYAML as a YAML parser

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -31,8 +31,8 @@ dependencies:
 - terminal-size
 - typed-process
 - optparse-applicative
-- yaml
 - aeson
+- HsYAML
 - filepattern
 - parsec
 - file-embed

--- a/src/Tenpureto/Orphanage.hs
+++ b/src/Tenpureto/Orphanage.hs
@@ -9,6 +9,9 @@ import qualified Data.Map                      as Map
 import           Data.HashMap.Strict.InsOrd     ( InsOrdHashMap )
 import qualified Data.HashMap.Strict.InsOrd    as InsOrdHashMap
 import           Data.Text.Prettyprint.Doc
+import           Data.YAML                      ( FromYAML(..)
+                                                , ToYAML(..)
+                                                )
 import           Path
 
 instance Pretty (Path a t) where
@@ -23,3 +26,9 @@ instance (Pretty a, Pretty b) => Pretty (Map a b) where
 instance (Pretty a, Pretty b) => Pretty (InsOrdHashMap a b) where
     pretty s =
         group . encloseSep "{ " " }" ", " $ pretty <$> InsOrdHashMap.toList s
+
+instance (Ord a, FromYAML a) => FromYAML (Set a) where
+    parseYAML x = Set.fromList <$> parseYAML x
+
+instance ToYAML a => ToYAML (Set a) where
+    toYAML = toYAML . Set.toList

--- a/src/Tenpureto/TemplateLoader/Internal.hs
+++ b/src/Tenpureto/TemplateLoader/Internal.hs
@@ -7,19 +7,23 @@ import           Data.Set                       ( Set )
 import qualified Data.Set                      as Set
 import           Data.Map                       ( Map )
 import qualified Data.Map                      as Map
-import qualified Data.HashMap.Strict           as HashMap
 import           Data.Text.Prettyprint.Doc
-import           Data.Yaml                      ( FromJSON(..)
-                                                , ToJSON(..)
+import           Data.YAML                      ( FromYAML(..)
+                                                , ToYAML(..)
+                                                , Pair
+                                                , Node
+                                                , withStr
+                                                , withMap
                                                 , (.:?)
                                                 , (.!=)
+                                                , mapping
                                                 , (.=)
                                                 )
-import qualified Data.Yaml                     as Y
-import           Data.Aeson.Types               ( KeyValue )
+import           Control.Applicative            ( (<|>) )
 
 import           Tenpureto.Graph
 import           Tenpureto.Effects.Git
+import           Tenpureto.Orphanage            ( )
 
 data FeatureStability = Deprecated | Experimental | Stable
         deriving (Show, Eq, Ord, Enum, Bounded)
@@ -78,57 +82,62 @@ instance Pretty TemplateYaml where
         , "Features: " <+> (align . pretty) (yamlFeatures cfg)
         ]
 
-instance FromJSON FeatureStability where
-    parseJSON (Y.String "stable"      ) = pure Stable
-    parseJSON (Y.String "experimental") = pure Experimental
-    parseJSON (Y.String "deprecated"  ) = pure Deprecated
-    parseJSON _                         = fail "Invalid feature stability value"
+instance FromYAML FeatureStability where
+    parseYAML = withStr "FeatureStability" $ \case
+        "stable"       -> pure Stable
+        "experimental" -> pure Experimental
+        "deprecated"   -> pure Deprecated
+        _              -> fail "Invalid feature stability value"
 
-instance ToJSON FeatureStability where
-    toJSON Stable       = toJSON @Text "stable"
-    toJSON Experimental = toJSON @Text "experimental"
-    toJSON Deprecated   = toJSON @Text "deprecated"
+instance ToYAML FeatureStability where
+    toYAML Stable       = toYAML @Text "stable"
+    toYAML Experimental = toYAML @Text "experimental"
+    toYAML Deprecated   = toYAML @Text "deprecated"
 
-instance FromJSON TemplateYamlFeature where
-    parseJSON (Y.String v) = pure $ TemplateYamlFeature
-        { yamlFeatureName        = v
-        , yamlFeatureDescription = Nothing
-        , yamlFeatureHidden      = False
-        , yamlFeatureStability   = Stable
-        }
-    parseJSON (Y.Object v) = case HashMap.toList v of
-        [(k, Y.Object vv)] ->
-            TemplateYamlFeature k
-                <$> (vv .:? "description")
-                <*> (vv .:? "hidden" .!= False)
-                <*> (vv .:? "stability" .!= Stable)
-        _ -> fail "Invalid template YAML feature definition"
-    parseJSON _ = fail "Invalid template YAML feature definition"
+instance FromYAML TemplateYamlFeature where
+    parseYAML yaml = simpleFeature yaml <|> complexFeature yaml
+      where
+        simpleFeature = withStr "TemplateYamlFeatureName"
+            $ \s -> pure (TemplateYamlFeature s Nothing False Stable)
+        complexFeature = withMap "TemplateYamlFeatureDefinition" $ \m ->
+            case Map.toList m of
+                [(k, v)] -> do
+                    kk <- parseYAML k
+                    withMap
+                        "TemplateYamlFeature"
+                        (\mm ->
+                            TemplateYamlFeature kk
+                                <$> (mm .:? "description")
+                                <*> (mm .:? "hidden" .!= False)
+                                <*> (mm .:? "stability" .!= Stable)
+                        )
+                        v
+                _ -> fail "Invalid template YAML feature definition"
 
-instance FromJSON TemplateYaml where
-    parseJSON (Y.Object v) =
+instance FromYAML TemplateYaml where
+    parseYAML = withMap "TemplateYaml" $ \v ->
         TemplateYaml
             <$> (Map.map (fromMaybe "") <$> v .:? "variables" .!= Map.empty)
             <*> (v .:? "features" .!= Set.empty)
             <*> (v .:? "excludes" .!= Set.empty)
             <*> (v .:? "conflicts" .!= Set.empty)
-    parseJSON _ = fail "Invalid template YAML definition"
 
-instance ToJSON TemplateYamlFeature where
-    toJSON TemplateYamlFeature { yamlFeatureName = n, yamlFeatureDescription = d, yamlFeatureHidden = h, yamlFeatureStability = s }
-        = case
-                catMaybes
-                    [ "description" .?= d
-                    , kvd "hidden"    False  h
-                    , kvd "stability" Stable s
-                    ]
-            of
-                []     -> toJSON n
-                fields -> Y.object [n .= (Y.object fields)]
+instance ToYAML TemplateYamlFeature where
+    toYAML TemplateYamlFeature { yamlFeatureName = n, yamlFeatureDescription = d, yamlFeatureHidden = h, yamlFeatureStability = s }
+        = case fields of
+            [] -> toYAML n
+            _  -> mapping [n .= mapping fields]
+      where
+        fields =
+            catMaybes
+                [ "description" .?= d
+                , kvd "hidden"    False  h
+                , kvd "stability" Stable s
+                ]
 
-instance ToJSON TemplateYaml where
-    toJSON TemplateYaml { yamlVariables = v, yamlFeatures = f, yamlExcludes = e, yamlConflicts = c }
-        = Y.object $ catMaybes
+instance ToYAML TemplateYaml where
+    toYAML TemplateYaml { yamlVariables = v, yamlFeatures = f, yamlExcludes = e, yamlConflicts = c }
+        = mappingMaybes
             [ "variables" .?= v
             , "features" .?= f
             , "excludes" .?= e
@@ -150,10 +159,13 @@ instance Monoid TemplateYaml where
                           , yamlConflicts = mempty
                           }
 
-(.?=) :: (KeyValue kv, ToJSON v, Eq v, Monoid v) => Text -> v -> Maybe kv
+mappingMaybes :: [Maybe Pair] -> Node ()
+mappingMaybes = mapping . catMaybes
+
+(.?=) :: (ToYAML v, Eq v, Monoid v) => Text -> v -> Maybe Pair
 (.?=) a b = if b == mempty then Nothing else Just (a .= b)
 
-kvd :: (KeyValue kv, ToJSON v, Eq v) => Text -> v -> v -> Maybe kv
+kvd :: (ToYAML v, Eq v) => Text -> v -> v -> Maybe Pair
 kvd a bd b = if b == bd then Nothing else Just (a .= b)
 
 requiredBranches :: TemplateBranchInformation -> Set Text

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,6 +5,7 @@ extra-deps:
 - hedgehog-classes-0.2.4.1
 - polysemy-1.2.2.0
 - polysemy-plugin-0.2.3.0
+- HsYAML-0.2.1.0
 
 nix:
   packages: [ zlib ]

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -25,6 +25,13 @@ packages:
       sha256: 3f5d41e30ed3cb19636243c1351c23b0159734ac99735133dbf58d75373036cd
   original:
     hackage: polysemy-plugin-0.2.3.0
+- completed:
+    hackage: HsYAML-0.2.1.0@sha256:e4677daeba57f7a1e9a709a1f3022fe937336c91513e893166bd1f023f530d68,5311
+    pantry-tree:
+      size: 1340
+      sha256: 21f61bf9cad31674126b106071dd9b852e408796aeffc90eec1792f784107eff
+  original:
+    hackage: HsYAML-0.2.1.0
 snapshots:
 - completed:
     size: 524163

--- a/test/Tenpureto/TemplateLoaderTest.hs
+++ b/test/Tenpureto/TemplateLoaderTest.hs
@@ -186,6 +186,40 @@ test_parseTemplateYaml =
                                }
     ]
 
+test_formatTemplateYaml :: [TestTree]
+test_formatTemplateYaml =
+    [ testCase "format simple features"
+        $   formatTemplateYaml
+                (TemplateYaml
+                    { yamlVariables = mempty
+                    , yamlFeatures  = Set.singleton TemplateYamlFeature
+                                          { yamlFeatureName        = "a"
+                                          , yamlFeatureDescription = Nothing
+                                          , yamlFeatureHidden      = False
+                                          , yamlFeatureStability   = Stable
+                                          }
+                    , yamlExcludes  = mempty
+                    , yamlConflicts = mempty
+                    }
+                )
+        @?= "features:\n- a\n"
+    , testCase "format extended features"
+        $ formatTemplateYaml
+              (TemplateYaml
+                  { yamlVariables = mempty
+                  , yamlFeatures  = Set.singleton TemplateYamlFeature
+                                        { yamlFeatureName        = "a"
+                                        , yamlFeatureDescription = Just "foo"
+                                        , yamlFeatureHidden      = False
+                                        , yamlFeatureStability   = Experimental
+                                        }
+                  , yamlExcludes  = mempty
+                  , yamlConflicts = mempty
+                  }
+              )
+        @?= "features:\n- a:\n    description: foo\n    stability: experimental\n"
+    ]
+
 test_buildGraph :: [TestTree]
 test_buildGraph =
     [ testCase "simple graph" $ nameGraph [a, b] @?= edge "a" "b"


### PR DESCRIPTION
This is a first step in fixing #13 — HsYAML by itself doesn't preserve mappings order, but it has an API that will make it possible.