### PR TITLE
Revert "Use HsYAML as a YAML parser"

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -31,8 +31,8 @@ dependencies:
 - terminal-size
 - typed-process
 - optparse-applicative
+- yaml
 - aeson
-- HsYAML
 - filepattern
 - parsec
 - file-embed

--- a/src/Tenpureto/Orphanage.hs
+++ b/src/Tenpureto/Orphanage.hs
@@ -9,9 +9,6 @@ import qualified Data.Map                      as Map
 import           Data.HashMap.Strict.InsOrd     ( InsOrdHashMap )
 import qualified Data.HashMap.Strict.InsOrd    as InsOrdHashMap
 import           Data.Text.Prettyprint.Doc
-import           Data.YAML                      ( FromYAML(..)
-                                                , ToYAML(..)
-                                                )
 import           Path
 
 instance Pretty (Path a t) where
@@ -26,9 +23,3 @@ instance (Pretty a, Pretty b) => Pretty (Map a b) where
 instance (Pretty a, Pretty b) => Pretty (InsOrdHashMap a b) where
     pretty s =
         group . encloseSep "{ " " }" ", " $ pretty <$> InsOrdHashMap.toList s
-
-instance (Ord a, FromYAML a) => FromYAML (Set a) where
-    parseYAML x = Set.fromList <$> parseYAML x
-
-instance ToYAML a => ToYAML (Set a) where
-    toYAML = toYAML . Set.toList

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,6 @@ extra-deps:
 - hedgehog-classes-0.2.4.1
 - polysemy-1.2.2.0
 - polysemy-plugin-0.2.3.0
-- HsYAML-0.2.1.0
 
 nix:
   packages: [ zlib ]

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -25,13 +25,6 @@ packages:
       sha256: 3f5d41e30ed3cb19636243c1351c23b0159734ac99735133dbf58d75373036cd
   original:
     hackage: polysemy-plugin-0.2.3.0
-- completed:
-    hackage: HsYAML-0.2.1.0@sha256:e4677daeba57f7a1e9a709a1f3022fe937336c91513e893166bd1f023f530d68,5311
-    pantry-tree:
-      size: 1340
-      sha256: 21f61bf9cad31674126b106071dd9b852e408796aeffc90eec1792f784107eff
-  original:
-    hackage: HsYAML-0.2.1.0
 snapshots:
 - completed:
     size: 524163

--- a/test/Tenpureto/TemplateLoaderTest.hs
+++ b/test/Tenpureto/TemplateLoaderTest.hs
@@ -186,40 +186,6 @@ test_parseTemplateYaml =
                                }
     ]
 
-test_formatTemplateYaml :: [TestTree]
-test_formatTemplateYaml =
-    [ testCase "format simple features"
-        $   formatTemplateYaml
-                (TemplateYaml
-                    { yamlVariables = mempty
-                    , yamlFeatures  = Set.singleton TemplateYamlFeature
-                                          { yamlFeatureName        = "a"
-                                          , yamlFeatureDescription = Nothing
-                                          , yamlFeatureHidden      = False
-                                          , yamlFeatureStability   = Stable
-                                          }
-                    , yamlExcludes  = mempty
-                    , yamlConflicts = mempty
-                    }
-                )
-        @?= "features:\n- a\n"
-    , testCase "format extended features"
-        $ formatTemplateYaml
-              (TemplateYaml
-                  { yamlVariables = mempty
-                  , yamlFeatures  = Set.singleton TemplateYamlFeature
-                                        { yamlFeatureName        = "a"
-                                        , yamlFeatureDescription = Just "foo"
-                                        , yamlFeatureHidden      = False
-                                        , yamlFeatureStability   = Experimental
-                                        }
-                  , yamlExcludes  = mempty
-                  , yamlConflicts = mempty
-                  }
-              )
-        @?= "features:\n- a:\n    description: foo\n    stability: experimental\n"
-    ]
-
 test_buildGraph :: [TestTree]
 test_buildGraph =
     [ testCase "simple graph" $ nameGraph [a, b] @?= edge "a" "b"


### PR DESCRIPTION
Reverts tenpureto/tenpureto#76. HsYAML is GPLv2/GPLv3 which is apparently not compatible with BSD 3-Clause.