### PR TITLE
Add a command to show template log

### DIFF
--- a/src/Tenpureto/Data.hs
+++ b/src/Tenpureto/Data.hs
@@ -19,6 +19,7 @@ data PreliminaryProjectConfiguration = PreliminaryProjectConfiguration
         , preSelectedBranches :: Maybe (Set Text)
         , preVariableValues :: Maybe (OrderedMap Text Text)
         , preVariableDefaultReplacements :: OrderedMap Text Text
+        , prePreviousMergedHeads :: Maybe [Committish]
         }
         deriving (Show)
 
@@ -50,6 +51,8 @@ instance Semigroup PreliminaryProjectConfiguration where
         , preVariableValues = preVariableValues a <|> preVariableValues b
         , preVariableDefaultReplacements = preVariableDefaultReplacements a
             `OrderedMap.union` preVariableDefaultReplacements b
+        , prePreviousMergedHeads = prePreviousMergedHeads a
+                                       <|> prePreviousMergedHeads b
         }
 
 instance Pretty PreliminaryProjectConfiguration where
@@ -66,6 +69,8 @@ instance Pretty PreliminaryProjectConfiguration where
             <+> (align . pretty) (preVariableValues cfg)
         , "Variable default replacements: "
             <+> (align . pretty) (preVariableDefaultReplacements cfg)
+        , "Previous merged heads: "
+            <+> (align . pretty) (prePreviousMergedHeads cfg)
         ]
 
 instance Pretty FinalProjectConfiguration where

--- a/src/Tenpureto/Internal.hs
+++ b/src/Tenpureto/Internal.hs
@@ -15,6 +15,7 @@ data TenpuretoException = TemplateBranchNotFoundException Text
                         | TenpuretoBranchNotDeleted Text
                         | TenpuretoEmptySelection
                         | TenpuretoEmptyChangeset
+                        | TenpuretoNoPreviousMergedHeads
                         | TenpuretoGitException GitException
                         | TenpuretoUIException UIException
                         | TenpuretoTemplateLoaderException TemplateLoaderException
@@ -32,6 +33,8 @@ instance Pretty TenpuretoException where
         "Cannot create a project from an empty selection"
     pretty TenpuretoEmptyChangeset =
         "Cannot create a commit because the changeset is empty"
+    pretty TenpuretoNoPreviousMergedHeads =
+        "Cannot find information about previously merged template commits"
     pretty (TenpuretoGitException            e) = pretty e
     pretty (TenpuretoUIException             e) = pretty e
     pretty (TenpuretoTemplateLoaderException e) = pretty e

--- a/src/Tenpureto/OrderedSet.hs
+++ b/src/Tenpureto/OrderedSet.hs
@@ -27,6 +27,11 @@ import           Algebra.Graph.AdjacencyMap     ( path
                                                 )
 import           Algebra.Graph.AdjacencyMap.Algorithm
                                                 ( topSort )
+import           Data.Text.Prettyprint.Doc      ( Pretty
+                                                , pretty
+                                                , group
+                                                , encloseSep
+                                                )
 
 newtype OrderedSet a = OrderedSet { toList :: [a] }
                                   deriving (Eq, Ord)
@@ -71,3 +76,6 @@ union a b = OrderedSet . sort $ ga `overlay` gb
 
 instance (Ord a, Show a) => Show (OrderedSet a) where
   show = show . toSet
+
+instance (Ord a, Pretty a) => Pretty (OrderedSet a) where
+  pretty s = group . encloseSep "[ " " ]" ", " $ pretty <$> toList s

--- a/test/TenpuretoTest.hs
+++ b/test/TenpuretoTest.hs
@@ -1,37 +1,50 @@
-{-# LANGUAGE QuasiQuotes #-}
-
 module TenpuretoTest where
 
 import           Test.Tasty
 import           Test.Tasty.HUnit
 
-import           Path
-
-import           Tenpureto.Data
 import           Tenpureto.Messages
 import qualified Tenpureto.OrderedMap          as OrderedMap
+import           Tenpureto.Effects.Git          ( Committish(..) )
 
 import           Tenpureto
 
 test_extractTemplateName :: [TestTree]
 test_extractTemplateName =
-    let cfg = FinalTemplateConfiguration { selectedTemplate = "foo/bar"
-                                         , targetDirectory  = [absdir|/tmp|]
-                                         }
-    in  [ testCase "should extract from create message"
-            $   extractTemplateName (commitCreateMessage "foo/bar" ["1", "2"])
-            @?= Just (selectedTemplate cfg)
-        , testCase "should extract from update message"
-            $   extractTemplateName (commitUpdateMessage "foo/bar" ["1", "2"])
-            @?= Just (selectedTemplate cfg)
-        , testCase "should extract from create message with additional text"
-            $   extractTemplateName
-                    (commitCreateMessage "foo/bar" ["1", "2"] <> "\nFoo foo foo")
-            @?= Just (selectedTemplate cfg)
-        , testCase "should not extract from other messages"
-            $   extractTemplateName "A\n\nTemplate foo/bar"
-            @?= Nothing
-        ]
+    [ testCase "should extract from create message"
+        $   extractTemplateName (commitCreateMessage "foo/bar" ["1", "2"])
+        @?= Just "foo/bar"
+    , testCase "should extract from update message"
+        $   extractTemplateName (commitUpdateMessage "foo/bar" ["1", "2"])
+        @?= Just "foo/bar"
+    , testCase "should extract from create message with additional text"
+        $   extractTemplateName
+                (commitCreateMessage "foo/bar" ["1", "2"] <> "Foo foo foo")
+        @?= Just "foo/bar"
+    , testCase "should not extract from other messages"
+        $   extractTemplateName "A\n\nTemplate foo/bar"
+        @?= Nothing
+    ]
+
+test_extractTemplateCommits :: [TestTree]
+test_extractTemplateCommits =
+    [ testCase "should extract from create message"
+        $   extractTemplateCommits (commitCreateMessage "foo/bar" ["1", "2"])
+        @?= [Committish "1", Committish "2"]
+    , testCase "should extract empty list from create message"
+        $   extractTemplateCommits (commitCreateMessage "foo/bar" [])
+        @?= []
+    , testCase "should extract from update message"
+        $   extractTemplateCommits (commitUpdateMessage "foo/bar" ["1", "2"])
+        @?= [Committish "1", Committish "2"]
+    , testCase "should extract from create message with additional text"
+        $   extractTemplateCommits
+                (commitCreateMessage "foo/bar" ["1", "2"] <> "Foo foo foo")
+        @?= [Committish "1", Committish "2"]
+    , testCase "should not extract from other messages"
+        $   extractTemplateCommits "A\n\nTemplate foo/bar"
+        @?= []
+    ]
 
 test_templateNameDefaultReplacement :: [TestTree]
 test_templateNameDefaultReplacement =


### PR DESCRIPTION
Partially implements #75

 * `tenpureto log <project-dir>` to show the log of all changes of relevant branches
 * `tenpureto log --included <project-dir>` to show the log of changes already included in the project
 * `tenpureto log --incoming <project-dir>` to show the log of changes that will come with the next update

`--included` and `--incoming` require the project to be created with a version of tenpureto that includes #81 (most likely, `0.6.0`)